### PR TITLE
Throw error for invalid package name

### DIFF
--- a/cmd/peace/main.go
+++ b/cmd/peace/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/umayr/peace"
 )
@@ -26,6 +27,10 @@ func main() {
 
 	if pkg == "" {
 		log.Fatal("Package name is required")
+	}
+
+	if strings.HasPrefix(pkg, "/") {
+		log.Fatal("Invalid package name")
 	}
 
 	r, err := peace.Do(pkg, tags, logging)


### PR DESCRIPTION
Will throw error if `/` is provided at the start of package name.